### PR TITLE
Custom acc and parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.vscode
 
 # C extensions
 *.so

--- a/docs/example_usage/training_lib_part_2.rst
+++ b/docs/example_usage/training_lib_part_2.rst
@@ -99,6 +99,22 @@ Adding these few lines right before calling of
 :meth:`~robustness.train.train_model`
 suffices for training our network robustly with this custom loss.
 
+As of the latest version of ``robustness``, you can now also supply a custom
+function for computing accuracy using the ``custom_accuracy`` flag. This should
+be a function that takes in the model output and the target labels, and returns
+a tuple of ``(top1, top5)`` accuracies (feel free to make the second element
+``float('nan')`` if there's only one accuracy metric you want to display). Here
+is an example:
+
+.. code-block:: python
+
+    def custom_acc_func(out, targ):
+        # Calculate top1 and top5 accuracy for this batch here
+        return 100., float('nan') # Return (top1, top5)
+    
+    train_args.custom_accuracy = custom_acc_func
+
+
 .. _using-custom-loaders:
 
 Training networks with custom data loaders

--- a/robustness/model_utils.py
+++ b/robustness/model_utils.py
@@ -51,7 +51,7 @@ class DummyModel(nn.Module):
         return self.model(x)
 
 def make_and_restore_model(*_, arch, dataset, resume_path=None,
-         parallel=True, pytorch_pretrained=False, add_custom_forward=False):
+         parallel=None, pytorch_pretrained=False, add_custom_forward=False):
     """
     Makes a model and (optionally) restores it from a checkpoint.
 
@@ -63,7 +63,7 @@ def make_and_restore_model(*_, arch, dataset, resume_path=None,
             robustness library (ignored if ``arch`` is not a string)
         not a string
         parallel (bool): if True, wrap the model in a DataParallel 
-            (default True, recommended)
+            (defaults to the same as ``resume_path is not None``)
         pytorch_pretrained (bool): if True, try to load a standard-trained 
             checkpoint from the torchvision library (throw error if failed)
         add_custom_forward (bool): ignored unless arch is an instance of
@@ -80,6 +80,7 @@ def make_and_restore_model(*_, arch, dataset, resume_path=None,
     """
     if (not isinstance(arch, str)) and add_custom_forward:
         arch = DummyModel(arch)
+    if parallel is None: parallel = (resume_path is not None)
 
     classifier_model = dataset.get_model(arch, pytorch_pretrained) if \
                             isinstance(arch, str) else arch

--- a/robustness/model_utils.py
+++ b/robustness/model_utils.py
@@ -51,7 +51,7 @@ class DummyModel(nn.Module):
         return self.model(x)
 
 def make_and_restore_model(*_, arch, dataset, resume_path=None,
-         parallel=None, pytorch_pretrained=False, add_custom_forward=False):
+         parallel=False, pytorch_pretrained=False, add_custom_forward=False):
     """
     Makes a model and (optionally) restores it from a checkpoint.
 
@@ -63,7 +63,7 @@ def make_and_restore_model(*_, arch, dataset, resume_path=None,
             robustness library (ignored if ``arch`` is not a string)
         not a string
         parallel (bool): if True, wrap the model in a DataParallel 
-            (defaults to the same as ``resume_path is not None``)
+            (defaults to False)
         pytorch_pretrained (bool): if True, try to load a standard-trained 
             checkpoint from the torchvision library (throw error if failed)
         add_custom_forward (bool): ignored unless arch is an instance of
@@ -80,7 +80,6 @@ def make_and_restore_model(*_, arch, dataset, resume_path=None,
     """
     if (not isinstance(arch, str)) and add_custom_forward:
         arch = DummyModel(arch)
-    if parallel is None: parallel = (resume_path is not None)
 
     classifier_model = dataset.get_model(arch, pytorch_pretrained) if \
                             isinstance(arch, str) else arch


### PR DESCRIPTION
Addresses an issue raised in #43 and adds a new feature:

- Makes the default for ``parallel`` equal to the None-ness of ``resume_path``. The reason for this is that if ``resume_path is None``, then this is likely a new model to be fed into ``train``, which expects a model that is not wrapped in DataParallel

- Allows for custom accuracy function to be supplied via the ``custom_accuracy`` training argument. The function should return a tuple ``(top1, top5)`` given the arguments ``(out, target)``.

- Update docs for example usage of custom_accuracy.