### PR TITLE
Fix small bug for loading subset of a dataset

### DIFF
--- a/robustness/loaders.py
+++ b/robustness/loaders.py
@@ -68,7 +68,7 @@ def make_loaders(workers, batch_size, transforms, data_path, data_aug=True,
         attrs = ["samples", "train_data", "data"]
         vals = {attr: hasattr(train_set, attr) for attr in attrs}
         assert any(vals.values()), f"dataset must expose one of {attrs}"
-        train_sample_count = len([k for k in vals if vals[k]][0])
+        train_sample_count = len(getattr(train_set,[k for k in vals if vals[k]][0]))
 
     if (not only_val) and (subset is not None) and (subset <= train_sample_count):
         assert not only_val
@@ -82,7 +82,6 @@ def make_loaders(workers, batch_size, transforms, data_path, data_aug=True,
             subset = np.arange(train_sample_count - subset, train_sample_count)
 
         train_set = Subset(train_set, subset)
-
     if not only_val:
         train_loader = DataLoader(train_set, batch_size=batch_size, 
             shuffle=shuffle_train, num_workers=workers, pin_memory=True)

--- a/robustness/loaders.py
+++ b/robustness/loaders.py
@@ -82,6 +82,7 @@ def make_loaders(workers, batch_size, transforms, data_path, data_aug=True,
             subset = np.arange(train_sample_count - subset, train_sample_count)
 
         train_set = Subset(train_set, subset)
+
     if not only_val:
         train_loader = DataLoader(train_set, batch_size=batch_size, 
             shuffle=shuffle_train, num_workers=workers, pin_memory=True)


### PR DESCRIPTION
`train_sample_count` was mistakenly set to the length of the attribute instead of the length of the attribute value. This will affect the subsequent lines of code
https://github.com/MadryLab/robustness/blob/cec6e4fd283f937d6d28f84e20103f5eb1e0070d/robustness/loaders.py#L73