### PR TITLE
Fixed static num_classes in VGG init.

### DIFF
--- a/robustness/cifar_models/vgg.py
+++ b/robustness/cifar_models/vgg.py
@@ -13,7 +13,7 @@ class VGG(nn.Module):
     def __init__(self, vgg_name, num_classes=10):
         super(VGG, self).__init__()
         self.features = self._make_layers(cfg[vgg_name])
-        self.classifier = nn.Linear(512, 10)
+        self.classifier = nn.Linear(512, num_classes)
 
     def forward(self, x, with_latent=False, fake_relu=False, no_relu=False):
         assert (not fake_relu) and (not no_relu),  \


### PR DESCRIPTION
The num_classes argument passed in VGG init is currently ignored.