### PR TITLE
fix type checking for dataset init and increment version

### DIFF
--- a/robustness/__init__.py
+++ b/robustness/__init__.py
@@ -1,2 +1,2 @@
 name = "robustness"
-__version__ = "1.0.post1"
+__version__ = "1.2.post1"

--- a/robustness/attack_steps.py
+++ b/robustness/attack_steps.py
@@ -122,7 +122,6 @@ class L2Step(AttackerStep):
     def step(self, x, g):
         """
         """
-        # Scale g so that each element of the batch is at least norm 1
         l = len(x.shape) - 1
         g_norm = ch.norm(g.view(g.shape[0], -1), dim=1).view(-1, *([1]*l))
         scaled_g = g / (g_norm + 1e-10)

--- a/robustness/datasets.py
+++ b/robustness/datasets.py
@@ -88,7 +88,8 @@ class DataSet(object):
         if len(extra_args) > 0: raise ValueError(f"Invalid arguments: {extra_args}")
         for k in kwargs:
             req_type = type(default_args[k])
-            if (default_args[k] is not None) and (not isinstance(kwargs[k], req_type)):
+            no_nones = (default_args[k] is not None) and (kwargs[k] is not None)
+            if no_nones and (not isinstance(kwargs[k], req_type)):
                 raise ValueError(f"Argument {k} should have type {req_type}")
         return {**default_args, **kwargs}
 

--- a/robustness/datasets.py
+++ b/robustness/datasets.py
@@ -88,7 +88,7 @@ class DataSet(object):
         if len(extra_args) > 0: raise ValueError(f"Invalid arguments: {extra_args}")
         for k in kwargs:
             req_type = type(default_args[k])
-            if not isinstance(kwargs[k], req_type):
+            if (default_args[k] is not None) and (not isinstance(kwargs[k], req_type)):
                 raise ValueError(f"Argument {k} should have type {req_type}")
         return {**default_args, **kwargs}
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
   # Versions should comply with PEP440.  For a discussion on single-sourcing
   # the version across setup.py and the project code, see
   # https://packaging.python.org/en/latest/single_source_version.html
-  version='1.2',
+  version='1.2.post1',
 
   description='Tools for Robustness',
   long_description=long_description,


### PR DESCRIPTION
- Previously, initializing a dataset with custom class directly didn't work, because of the type checking put in during the last version. This is fixed by not type checking if there is no default argument.
- Removed a misleading comment
- Increment the version so that ``robustness.__version__`` returns the right thing. 