### PR TITLE
Add resnet34 for CIFAR

### DIFF
--- a/robustness/cifar_models/resnet.py
+++ b/robustness/cifar_models/resnet.py
@@ -131,6 +131,7 @@ def ResNet152(**kwargs):
 
 resnet50 = ResNet50
 resnet18 = ResNet18
+resnet34 = ResNet34
 resnet101 = ResNet101
 resnet152 = ResNet152
 resnet18wide = ResNet18Wide


### PR DESCRIPTION
The line "resnet34 = ResNet34" is missing in cifar_models/resnet.py
Got a KeyError when trying to use resnet34 with CIFAR. This solves the issue