### PR TITLE
import load_state_dict_from_url from torch.hub

### DIFF
--- a/robustness/imagenet_models/alexnet.py
+++ b/robustness/imagenet_models/alexnet.py
@@ -1,5 +1,5 @@
 import torch.nn as nn
-from torchvision.models.utils import load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 from ..tools.custom_modules import FakeReLUM
 
 __all__ = ['AlexNet', 'alexnet']

--- a/robustness/imagenet_models/squeezenet.py
+++ b/robustness/imagenet_models/squeezenet.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.init as init
-from torchvision.models.utils import load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 from ..tools.custom_modules import FakeReLUM
 
 

--- a/robustness/imagenet_models/vgg.py
+++ b/robustness/imagenet_models/vgg.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 import torch
-from torchvision.models.utils import load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 from ..tools.custom_modules import FakeReLUM
 
 __all__ = [


### PR DESCRIPTION
This replaces

```
from torchvision.models.utils import load_state_dict_from_url
```

with

```
from torch.hub import load_state_dict_from_url
```

Recent versions of torchvision no longer have that namespace, and a
ModuleNotFoundError is raised.

I considered using a try-except block to try loading from one of those
imports and then fallback to the other import. But I chose not to do
that because other files already use the
`torch.hub.load_state_dict_from_url` function. Those lines were added 2
years ago (eg
https://github.com/MadryLab/robustness/commit/52a345bd46e09fc1f79a926048a40d6bf150618d).
Because the `torch.hub` namespace has been used in other parts of the
project for so long, it seems reasonable to me to simply replace
`torchvision.models.utils` with `torch.hub`.